### PR TITLE
Specific social shares take 2

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -119,6 +119,7 @@ exports.createPages = ({ graphql, actions }) => {
             node {
               frontmatter {
                 title
+                videoId
               }
               fields {
                 slug
@@ -135,6 +136,7 @@ exports.createPages = ({ graphql, actions }) => {
             component: path.resolve('./src/templates/article.js'),
             context: {
               slug: node.fields.slug,
+              videoId: node.frontmatter.videoId,
               prevSlug:
                 articles[index - 1] && articles[index - 1].node.fields.slug,
               nextSlug:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "react-helmet": "^5.2.0",
         "react-player": "^1.6.4",
         "react-share": "^2.1.1",
+        "react-textarea-autosize": "^7.0.3",
         "react-twitter-widgets": "^1.7.1",
         "slugify": "^1.3.0",
         "styled-components": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "build": "gatsby build",
         "debug-build": "node --inspect-brk ./node_modules/gatsby/dist/bin/gatsby.js build",
         "develop": "gatsby develop",
+        "debug-develop": "node --inspect-brk ./node_modules/gatsby/dist/bin/gatsby.js develop",
         "format": "prettier --write 'src/**/*.js'",
         "test": "echo \"Error: no test specified\" && exit 1"
     },

--- a/src/Content.js
+++ b/src/Content.js
@@ -206,10 +206,7 @@ export const Footer = () => (
         >
           <TwitterIcon size={32} round={true} />
         </TwitterShareButton>
-        <FacebookShareButton
-          title="Do you buy more books than you read? Learn while you poop! Learn React and its ecosystem in 2 minutes per day /@swizec"
-          url="https://learnwhileyoupoop.com"
-        >
+        <FacebookShareButton url="https://learnwhileyoupoop.com">
           <FacebookIcon size={32} round={true} />
         </FacebookShareButton>
       </div>

--- a/src/components/ShareDialog.js
+++ b/src/components/ShareDialog.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import styled from 'styled-components'
+import Textarea from 'react-textarea-autosize'
+
+import {
+  FacebookShareButton,
+  TwitterShareButton,
+  TwitterIcon,
+  FacebookIcon,
+} from 'react-share'
+
+import { FluffySection } from '../components/Section'
+import { FormControl } from 'react-bootstrap'
+import { MiddleColumn } from '../components/Columns'
+
+import Signature from '../img/signature.gif'
+
+const CenteredDiv = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+export default class ShareDialog extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      sharePlaceholder: props.sharePlaceholder,
+    }
+  }
+
+  handleChange = event => {
+    this.setState({ sharePlaceholder: event.target.value })
+  }
+
+  render() {
+    return (
+      <FluffySection>
+        <MiddleColumn>
+          <p style={{ textAlign: 'center' }}>
+            Know someone who wants to learn React and its whole ecosystem? Share
+            👇
+          </p>
+          <CenteredDiv>
+            <FormControl
+              componentClass={Textarea}
+              style={{
+                textAlign: 'center',
+                width: '500px',
+                fontSize: '1.5rem',
+              }}
+              value={this.state.sharePlaceholder}
+              onChange={this.handleChange}
+            />
+          </CenteredDiv>
+          <br />
+          <CenteredDiv>
+            <TwitterShareButton
+              via="swizec"
+              title={this.state.sharePlaceholder}
+              url={this.props.url}
+            >
+              <TwitterIcon size={32} round={true} />
+            </TwitterShareButton>
+            <FacebookShareButton url={this.props.url}>
+              <FacebookIcon size={32} round={true} />
+            </FacebookShareButton>
+          </CenteredDiv>
+          <p>
+            Cheers,<br />
+            ~Swizec<br />
+            <img
+              src={Signature}
+              style={{ width: '200px', margin: '1.5em 0' }}
+            />
+          </p>
+        </MiddleColumn>
+      </FluffySection>
+    )
+  }
+}

--- a/src/components/ShareDialog.js
+++ b/src/components/ShareDialog.js
@@ -47,7 +47,6 @@ export default class ShareDialog extends React.Component {
               style={{
                 textAlign: 'center',
                 width: '500px',
-                fontSize: '1.5rem',
               }}
               value={this.state.sharePlaceholder}
               onChange={this.handleChange}

--- a/src/components/SocialHelmet.js
+++ b/src/components/SocialHelmet.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import Helmet from 'react-helmet'
+
+export default ({ url, title, description, imageSrc }) => {
+  return (
+    <Helmet>
+      {/* OpenGraph tags */}
+      <meta property="og:url" content={url} />
+      <meta property="og:type" content="article" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={imageSrc} />
+
+      {/* Twitter Card tags */}
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={imageSrc} />
+    </Helmet>
+  )
+}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -52,7 +52,6 @@ const Layout = ({ children, data }) => (
     <div className="bg-white-dark padding-small-top" />
 
     {children}
-    <Content.Footer />
   </div>
 )
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,6 +20,7 @@ const IndexPage = ({ data }) => {
           )
         }
       />
+      <Content.Footer />
     </Layout>
   )
 }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import Layout from '../components/layout'
 import ResponsivePlayer from '../components/ResponsivePlayer'
+import SocialHelmet from '../components/SocialHelmet.js'
 
 import Pagination from '../components/Pagination'
 import { FluffySection, LowSection } from '../components/Section'
@@ -91,13 +92,21 @@ export default ({ data, pathContext }) => {
   const { slug } = pathContext
   const url = `https://learnwhileyoupoop.com/${slug}`
 
+  const yt = data.ytVideo
+
   const sharePlaceholder = `Here's a great lesson I just learned from @swizec: '${title}' · It's a ⏱ 2min 🎥 + an in-depth article 🔥 · Best company for the 🚽😅`
   return (
     <Layout>
+      <SocialHelmet
+        url={url}
+        title={yt.title}
+        description={yt.description}
+        imageSrc={yt.thumbnails.high.url}
+      />
       <Pagination pathContext={pathContext} small />
       <LowSection>
         <Row>
-          <ResponsivePlayer videoId={article.frontmatter.videoId} />
+          <ResponsivePlayer videoId={yt.videoId} />
         </Row>
         <Row>
           <Column md={11} mdOffset={1}>
@@ -112,13 +121,24 @@ export default ({ data, pathContext }) => {
 }
 
 export const query = graphql`
-  query ArticleQuery($slug: String!) {
+  query ArticleQuery($slug: String!, $videoId: String!) {
     markdownRemark(fields: { slug: { eq: $slug } }) {
       html
       frontmatter {
-        videoId
         title
       }
+    }
+    ytVideo(videoId: { eq: $videoId }) {
+      title
+      videoId
+      thumbnails {
+        high {
+          url
+          width
+          height
+        }
+      }
+      description
     }
   }
 `

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -3,9 +3,18 @@ import React from 'react'
 import Layout from '../components/layout'
 import ResponsivePlayer from '../components/ResponsivePlayer'
 
-import { LowSection } from '../components/Section'
 import Pagination from '../components/Pagination'
 import { Row, Col as Column } from 'react-bootstrap'
+import { FluffySection, LowSection } from '../components/Section'
+
+import {
+  FacebookShareButton,
+  TwitterShareButton,
+  TwitterIcon,
+  FacebookIcon,
+} from 'react-share'
+import Signature from '../img/signature.gif'
+import { MiddleColumn } from '../components/Columns'
 
 export default ({ data, pathContext }) => {
   const article = data.markdownRemark
@@ -24,6 +33,43 @@ export default ({ data, pathContext }) => {
         </Row>
       </LowSection>
       <Pagination pathContext={pathContext} />
+      <FluffySection>
+        <MiddleColumn>
+          <p>
+            Know someone who wants to learn React and its whole ecosystem? Share
+            👇
+          </p>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <TwitterShareButton
+              via="swizec"
+              title="Do you buy more books than you read? Learn while you poop! Learn React and its ecosystem in 2 minutes per day /@swizec"
+              url="https://learnwhileyoupoop.com"
+            >
+              <TwitterIcon size={32} round={true} />
+            </TwitterShareButton>
+            <FacebookShareButton
+              title="Do you buy more books than you read? Learn while you poop! Learn React and its ecosystem in 2 minutes per day /@swizec"
+              url="https://learnwhileyoupoop.com"
+            >
+              <FacebookIcon size={32} round={true} />
+            </FacebookShareButton>
+          </div>
+          <p>
+            Cheers,<br />
+            ~Swizec<br />
+            <img
+              src={Signature}
+              style={{ width: '200px', margin: '1.5em 0' }}
+            />
+          </p>
+        </MiddleColumn>
+      </FluffySection>
     </Layout>
   )
 }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -4,8 +4,8 @@ import Layout from '../components/layout'
 import ResponsivePlayer from '../components/ResponsivePlayer'
 
 import Pagination from '../components/Pagination'
-import { Row, Col as Column } from 'react-bootstrap'
 import { FluffySection, LowSection } from '../components/Section'
+import { FormControl, Row, Col as Column } from 'react-bootstrap'
 
 import {
   FacebookShareButton,
@@ -16,9 +16,83 @@ import {
 import Signature from '../img/signature.gif'
 import { MiddleColumn } from '../components/Columns'
 
+import styled from 'styled-components'
+import Textarea from 'react-textarea-autosize'
+
+const CenteredDiv = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+class ShareDialog extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      sharePlaceholder: props.sharePlaceholder,
+    }
+  }
+
+  handleChange = event => {
+    this.setState({ sharePlaceholder: event.target.value })
+  }
+
+  render() {
+    return (
+      <FluffySection>
+        <MiddleColumn>
+          <p style={{ textAlign: 'center' }}>
+            Know someone who wants to learn React and its whole ecosystem? Share
+            👇
+          </p>
+          <CenteredDiv>
+            <FormControl
+              componentClass={Textarea}
+              style={{
+                textAlign: 'center',
+                width: '500px',
+                minHeight: '8rem',
+                fontSize: '1.5rem',
+              }}
+              value={this.state.sharePlaceholder}
+              onChange={this.handleChange}
+            />
+          </CenteredDiv>
+          <br />
+          <CenteredDiv>
+            <TwitterShareButton
+              via="swizec"
+              title={this.state.sharePlaceholder}
+              url={`https://learnwhileyoupoop.com/${this.props.slug}`}
+            >
+              <TwitterIcon size={32} round={true} />
+            </TwitterShareButton>
+            <FacebookShareButton
+              url={`https://learnwhileyoupoop.com/${this.props.slug}`}
+            >
+              <FacebookIcon size={32} round={true} />
+            </FacebookShareButton>
+          </CenteredDiv>
+          <p>
+            Cheers,<br />
+            ~Swizec<br />
+            <img
+              src={Signature}
+              style={{ width: '200px', margin: '1.5em 0' }}
+            />
+          </p>
+        </MiddleColumn>
+      </FluffySection>
+    )
+  }
+}
+
 export default ({ data, pathContext }) => {
   const article = data.markdownRemark
+  const title = article.frontmatter.title
+  const { slug } = pathContext
 
+  const sharePlaceholder = `Here's a great lesson I just learned from @swizec: '${title}' · It's a ⏱ 2min 🎥 + an in-depth article 🔥 · Best company for the 🚽😅`
   return (
     <Layout>
       <Pagination pathContext={pathContext} small />
@@ -33,43 +107,7 @@ export default ({ data, pathContext }) => {
         </Row>
       </LowSection>
       <Pagination pathContext={pathContext} />
-      <FluffySection>
-        <MiddleColumn>
-          <p>
-            Know someone who wants to learn React and its whole ecosystem? Share
-            👇
-          </p>
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <TwitterShareButton
-              via="swizec"
-              title="Do you buy more books than you read? Learn while you poop! Learn React and its ecosystem in 2 minutes per day /@swizec"
-              url="https://learnwhileyoupoop.com"
-            >
-              <TwitterIcon size={32} round={true} />
-            </TwitterShareButton>
-            <FacebookShareButton
-              title="Do you buy more books than you read? Learn while you poop! Learn React and its ecosystem in 2 minutes per day /@swizec"
-              url="https://learnwhileyoupoop.com"
-            >
-              <FacebookIcon size={32} round={true} />
-            </FacebookShareButton>
-          </div>
-          <p>
-            Cheers,<br />
-            ~Swizec<br />
-            <img
-              src={Signature}
-              style={{ width: '200px', margin: '1.5em 0' }}
-            />
-          </p>
-        </MiddleColumn>
-      </FluffySection>
+      <ShareDialog sharePlaceholder={sharePlaceholder} slug={slug} />
     </Layout>
   )
 }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -63,13 +63,11 @@ class ShareDialog extends React.Component {
             <TwitterShareButton
               via="swizec"
               title={this.state.sharePlaceholder}
-              url={`https://learnwhileyoupoop.com/${this.props.slug}`}
+              url={this.props.url}
             >
               <TwitterIcon size={32} round={true} />
             </TwitterShareButton>
-            <FacebookShareButton
-              url={`https://learnwhileyoupoop.com/${this.props.slug}`}
-            >
+            <FacebookShareButton url={this.props.url}>
               <FacebookIcon size={32} round={true} />
             </FacebookShareButton>
           </CenteredDiv>
@@ -91,6 +89,7 @@ export default ({ data, pathContext }) => {
   const article = data.markdownRemark
   const title = article.frontmatter.title
   const { slug } = pathContext
+  const url = `https://learnwhileyoupoop.com/${slug}`
 
   const sharePlaceholder = `Here's a great lesson I just learned from @swizec: '${title}' · It's a ⏱ 2min 🎥 + an in-depth article 🔥 · Best company for the 🚽😅`
   return (
@@ -107,7 +106,7 @@ export default ({ data, pathContext }) => {
         </Row>
       </LowSection>
       <Pagination pathContext={pathContext} />
-      <ShareDialog sharePlaceholder={sharePlaceholder} slug={slug} />
+      <ShareDialog sharePlaceholder={sharePlaceholder} url={url} />
     </Layout>
   )
 }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -3,88 +3,11 @@ import React from 'react'
 import Layout from '../components/layout'
 import ResponsivePlayer from '../components/ResponsivePlayer'
 import SocialHelmet from '../components/SocialHelmet.js'
+import ShareDialog from '../components/ShareDialog.js'
 
+import { LowSection } from '../components/Section'
 import Pagination from '../components/Pagination'
-import { FluffySection, LowSection } from '../components/Section'
-import { FormControl, Row, Col as Column } from 'react-bootstrap'
-
-import {
-  FacebookShareButton,
-  TwitterShareButton,
-  TwitterIcon,
-  FacebookIcon,
-} from 'react-share'
-import Signature from '../img/signature.gif'
-import { MiddleColumn } from '../components/Columns'
-
-import styled from 'styled-components'
-import Textarea from 'react-textarea-autosize'
-
-const CenteredDiv = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`
-
-class ShareDialog extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      sharePlaceholder: props.sharePlaceholder,
-    }
-  }
-
-  handleChange = event => {
-    this.setState({ sharePlaceholder: event.target.value })
-  }
-
-  render() {
-    return (
-      <FluffySection>
-        <MiddleColumn>
-          <p style={{ textAlign: 'center' }}>
-            Know someone who wants to learn React and its whole ecosystem? Share
-            👇
-          </p>
-          <CenteredDiv>
-            <FormControl
-              componentClass={Textarea}
-              style={{
-                textAlign: 'center',
-                width: '500px',
-                minHeight: '8rem',
-                fontSize: '1.5rem',
-              }}
-              value={this.state.sharePlaceholder}
-              onChange={this.handleChange}
-            />
-          </CenteredDiv>
-          <br />
-          <CenteredDiv>
-            <TwitterShareButton
-              via="swizec"
-              title={this.state.sharePlaceholder}
-              url={this.props.url}
-            >
-              <TwitterIcon size={32} round={true} />
-            </TwitterShareButton>
-            <FacebookShareButton url={this.props.url}>
-              <FacebookIcon size={32} round={true} />
-            </FacebookShareButton>
-          </CenteredDiv>
-          <p>
-            Cheers,<br />
-            ~Swizec<br />
-            <img
-              src={Signature}
-              style={{ width: '200px', margin: '1.5em 0' }}
-            />
-          </p>
-        </MiddleColumn>
-      </FluffySection>
-    )
-  }
-}
+import { Row, Col as Column } from 'react-bootstrap'
 
 export default ({ data, pathContext }) => {
   const article = data.markdownRemark

--- a/yarn.lock
+++ b/yarn.lock
@@ -8926,6 +8926,12 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
+react-textarea-autosize@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.0.3.tgz#a7b35b86d0b9cd8f13cb446ed8145d7df3239056"
+  dependencies:
+    prop-types "^15.6.0"
+
 react-transition-group@^2.0.0, react-transition-group@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"


### PR DESCRIPTION
Taking social meta tag information from Youtube nodes.

This assumes that the lwyp format is always video+article, that is, that every lesson's `.md` has a valid `videoId` frontmatter field. (This is true for all current ones.)

**Important:** at the moment, `gatsby-node.js` only creates `ytVideo` nodes for the `react` playlist, not the `state` playlist. I'm going to fix that in a separate PR, making it easy to add new playlists. That PR should be merged before this one.