### PR TITLE
Fix social meta tags for images on home page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,6 +15,10 @@ const playlistIds = {
 const slugify = require('slugify')
 const path = require('path')
 
+if (process.env.NODE_ENV === 'development') {
+  process.env.GATSBY_WEBPACK_PUBLICPATH = '/'
+}
+
 exports.sourceNodes = ({ actions }) => {
   const { createNode } = actions
   const makeNode = node => {


### PR DESCRIPTION
By default (and rather confusingly), Gatsby uses a `publicPath` with
fully-qualified domain name when in development, but only relative path
when in production. This fixes that, setting both to relative paths.

Cf.: https://github.com/gatsbyjs/gatsby/issues/5264