### PR TITLE
Link to articles from titles on home page

### DIFF
--- a/src/components/CurriculumLink.js
+++ b/src/components/CurriculumLink.js
@@ -2,19 +2,13 @@ import React from 'react'
 import styled from 'styled-components'
 import { Link } from 'gatsby'
 
-const ClickableH3 = styled.h3`
-  cursor: pointer;
-`
-
-const Description = styled.div`
-  width: 720px;
-`
-
-const CenteredDesc = Description.extend`
-  text-align: center;
-
-  @media (max-width: 720px) {
-    width: 95%;
+const TitleLink = styled(Link)`
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    border-bottom-style: none;
+    color: inherit;
   }
 `
 
@@ -23,16 +17,12 @@ class CurriculumLink extends React.Component {
     const { video, article } = this.props
 
     return (
-      <div>
-        <ClickableH3 onClick={this.onClick}>
-          {'👉'}{' '}
-          {article && article.fields && article.fields.slug ? (
-            <Link to={article.fields.slug}>{video.title.split('|')[0]}</Link>
-          ) : (
-            video.title.split('|')[0]
-          )}
-        </ClickableH3>
-      </div>
+      <h3>
+        {'👉'}{' '}
+        <TitleLink to={article.fields.slug}>
+          {video.title.split('|')[0]}
+        </TitleLink>
+      </h3>
     )
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -47,6 +47,9 @@ export const query = graphql`
           frontmatter {
             videoId
           }
+          fields {
+            slug
+          }
         }
       }
     }


### PR DESCRIPTION
They don't expand in place anymore, so this makes them link to the article page. Staging: https://public-lyftcjdepa.now.sh/

Note that the `now` deployment doesn't include #10 so the fonts are broken.