### PR TITLE
Fix and bulletproof page path inconsistencies

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -107,8 +107,8 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 
     actions.createNodeField({
       node,
-      name: 'slug',
-      value: slug,
+      name: 'pagePath',
+      value: '/' + slug,
     })
   }
 }
@@ -127,7 +127,7 @@ exports.createPages = ({ graphql, actions }) => {
                 videoId
               }
               fields {
-                slug
+                pagePath
               }
             }
           }
@@ -137,15 +137,15 @@ exports.createPages = ({ graphql, actions }) => {
       result.data.allMarkdownRemark.edges.forEach(
         ({ node }, index, articles) => {
           createPage({
-            path: node.fields.slug,
+            path: node.fields.pagePath,
             component: path.resolve('./src/templates/article.js'),
             context: {
-              slug: node.fields.slug,
+              pagePath: node.fields.pagePath,
               videoId: node.frontmatter.videoId,
-              prevSlug:
-                articles[index - 1] && articles[index - 1].node.fields.slug,
-              nextSlug:
-                articles[index + 1] && articles[index + 1].node.fields.slug,
+              prevPagePath:
+                articles[index - 1] && articles[index - 1].node.fields.pagePath,
+              nextPagePath:
+                articles[index + 1] && articles[index + 1].node.fields.pagePath,
               prevTitle:
                 articles[index - 1] &&
                 articles[index - 1].node.frontmatter.title,

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "scripts": {
         "deploy": "rm -rf .cache/ public/ && gatsby build && cd public/ && now && cd ..",
         "build": "gatsby build",
-        "debug-build": "node --inspect-brk ./node_modules/gatsby/dist/bin/gatsby.js build",
+        "debug-build": "rm -rf .cache/ && ndb ./node_modules/gatsby/dist/bin/gatsby.js build",
         "develop": "gatsby develop",
-        "debug-develop": "node --inspect-brk ./node_modules/gatsby/dist/bin/gatsby.js develop",
+        "debug-develop": "ndb ./node_modules/gatsby/dist/bin/gatsby.js develop",
         "serve": "yarn build && gatsby serve",
         "reboot": "git stash && git clean -xdf -e now-secrets.json && git stash apply && yarn && yarn serve",
         "rebuild": "rm -rf .cache/ public/ && yarn serve",
@@ -51,6 +51,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "devDependencies": {
+        "ndb": "^1.0.19",
         "prettier": "^1.12.0"
     }
 }

--- a/src/components/CurriculumLink.js
+++ b/src/components/CurriculumLink.js
@@ -15,13 +15,16 @@ const TitleLink = styled(Link)`
 class CurriculumLink extends React.Component {
   render() {
     const { video, article } = this.props
+    const title = video.title.split('|')[0]
+
+    // Sometimes there's a video in the playlist but the article hasn't been
+    // written yet
+    const pagePath = article && article.fields && article.fields.pagePath
 
     return (
       <h3>
-        {'👉'}{' '}
-        <TitleLink to={article.fields.slug}>
-          {video.title.split('|')[0]}
-        </TitleLink>
+        {'👉'}
+        {pagePath ? <TitleLink to={pagePath}>{title}</TitleLink> : title}
       </h3>
     )
   }

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -4,25 +4,17 @@ import { Pager } from 'react-bootstrap'
 import { Link } from 'gatsby'
 
 const Pagination = ({ pathContext, small }) => {
-  const { prevSlug, nextSlug, prevTitle, nextTitle } = pathContext
+  const { prevPagePath, nextPagePath, prevTitle, nextTitle } = pathContext
   return (
     <Pager>
       {!small ? <p>👓&nbsp;Keep on learnin'&nbsp;👓</p> : null}
-      {prevSlug && (
-        <Pager.Item
-          href={'/' + prevSlug}
-          componentClass={Link}
-          to={'/' + prevSlug}
-        >
+      {prevPagePath && (
+        <Pager.Item href={prevPagePath} componentClass={Link} to={prevPagePath}>
           &larr;&nbsp;Previous lesson: {prevTitle}
         </Pager.Item>
       )}
-      {nextSlug && (
-        <Pager.Item
-          href={'/' + nextSlug}
-          componentClass={Link}
-          to={'/' + nextSlug}
-        >
+      {nextPagePath && (
+        <Pager.Item href={nextPagePath} componentClass={Link} to={nextPagePath}>
           Next lesson:&nbsp;{nextTitle}&nbsp;&rarr;
         </Pager.Item>
       )}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,7 +48,7 @@ export const query = graphql`
             videoId
           }
           fields {
-            slug
+            pagePath
           }
         }
       }

--- a/src/pages/state.js
+++ b/src/pages/state.js
@@ -48,7 +48,7 @@ export const query = graphql`
             videoId
           }
           fields {
-            slug
+            pagePath
           }
         }
       }

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -12,8 +12,8 @@ import { Row, Col as Column } from 'react-bootstrap'
 export default ({ data, pathContext }) => {
   const article = data.markdownRemark
   const title = article.frontmatter.title
-  const { slug } = pathContext
-  const url = `https://learnwhileyoupoop.com/${slug}`
+  const { pagePath } = pathContext
+  const url = `https://learnwhileyoupoop.com${pagePath}`
 
   const yt = data.ytVideo
 
@@ -44,8 +44,8 @@ export default ({ data, pathContext }) => {
 }
 
 export const query = graphql`
-  query ArticleQuery($slug: String!, $videoId: String!) {
-    markdownRemark(fields: { slug: { eq: $slug } }) {
+  query ArticleQuery($pagePath: String!, $videoId: String!) {
+    markdownRemark(fields: { pagePath: { eq: $pagePath } }) {
       html
       frontmatter {
         title

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,6 +969,12 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
+agent-base@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  dependencies:
+    es6-promisify "^5.0.0"
+
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -2126,12 +2132,23 @@ buffer-alloc-unsafe@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz#ffe1f67551dd055737de253337bfe853dfab1a6a"
 
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+
 buffer-alloc@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.1.0.tgz#05514d33bf1656d3540c684f65b1202e90eca303"
   dependencies:
     buffer-alloc-unsafe "^0.1.0"
     buffer-fill "^0.1.0"
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
@@ -2148,6 +2165,10 @@ buffer-equal@0.0.1:
 buffer-fill@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-0.1.1.tgz#76d825c4d6e50e06b7a31eb520c04d08cc235071"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^1.0.0:
   version "1.0.0"
@@ -2435,7 +2456,7 @@ chokidar@^1.7.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.0, chokidar@^2.0.2:
+chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
@@ -2457,6 +2478,10 @@ chokidar@^2.0.0, chokidar@^2.0.2:
 chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
+chrome-devtools-frontend@1.0.578928:
+  version "1.0.578928"
+  resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.578928.tgz#7ed0e1756a0b450b6e67ccaff628503209c44b38"
 
 chrome-trace-event@^1.0.0:
   version "1.0.0"
@@ -2520,7 +2545,7 @@ clipboard@^2.0.0:
     select "^1.1.2"
     tiny-emitter "^2.0.0"
 
-clipboardy@1.2.3:
+clipboardy@1.2.3, clipboardy@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-1.2.3.tgz#0526361bf78724c1f20be248d428e365433c07ef"
   dependencies:
@@ -2728,7 +2753,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@1.6.2, concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -3206,7 +3231,7 @@ decompress-targz@^3.0.0:
     through2 "^0.6.1"
     vinyl "^0.4.3"
 
-decompress-targz@^4.0.0:
+decompress-targz@^4.0.0, decompress-targz@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/decompress-targz/-/decompress-targz-4.1.1.tgz#c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee"
   dependencies:
@@ -3249,7 +3274,7 @@ decompress@^3.0.0:
     vinyl-assign "^1.0.1"
     vinyl-fs "^2.2.0"
 
-decompress@^4.0.0:
+decompress@^4.0.0, decompress@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
   dependencies:
@@ -3803,6 +3828,16 @@ es6-promise@^3.0.2:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
 
+es6-promise@^4.0.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
+
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
@@ -4212,6 +4247,15 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+extract-zip@^1.6.6:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
+  dependencies:
+    concat-stream "1.6.2"
+    debug "2.6.9"
+    mkdirp "0.5.1"
+    yauzl "2.4.1"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -5739,6 +5783,13 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+https-proxy-agent@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -6342,6 +6393,12 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
 isarray@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
+
+isbinaryfile@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80"
+  dependencies:
+    buffer-alloc "^1.2.0"
 
 isemail@3.x.x:
   version "3.1.2"
@@ -7225,7 +7282,7 @@ mime@^1.3.4, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
-mime@^2.0.3, mime@^2.1.0, mime@^2.2.0:
+mime@^2.0.3, mime@^2.1.0, mime@^2.2.0, mime@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
 
@@ -7386,7 +7443,7 @@ name-all-modules-plugin@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/name-all-modules-plugin/-/name-all-modules-plugin-1.0.1.tgz#0abfb6ad835718b9fb4def0674e06657a954375c"
 
-nan@^2.10.0, nan@^2.9.2:
+nan@2.10.0, nan@^2.10.0, nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -7410,6 +7467,33 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+ndb-node-pty-prebuilt@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/ndb-node-pty-prebuilt/-/ndb-node-pty-prebuilt-0.8.0.tgz#dbe8df675d94cd28697e399925137cc71c089bee"
+  dependencies:
+    decompress "^4.2.0"
+    decompress-targz "^4.1.1"
+    nan "2.10.0"
+
+ndb@^1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/ndb/-/ndb-1.0.19.tgz#f3bdec920e52f4bb3688619529634e081fd686db"
+  dependencies:
+    chokidar "^2.0.4"
+    chrome-devtools-frontend "1.0.578928"
+    clipboardy "^1.2.3"
+    fs-copy-file-sync "^1.1.1"
+    isbinaryfile "^3.0.2"
+    mime "^2.3.1"
+    opn "^5.3.0"
+    puppeteer "1.6.1"
+    rimraf "^2.6.2"
+    update-notifier "^2.5.0"
+    ws "^6.0.0"
+    xterm "^3.5.1"
+  optionalDependencies:
+    ndb-node-pty-prebuilt "^0.8.0"
 
 needle@^2.2.0:
   version "2.2.0"
@@ -8622,6 +8706,10 @@ proxy-addr@~2.0.3:
     forwarded "~0.1.2"
     ipaddr.js "1.6.0"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -8677,6 +8765,19 @@ punycode@^1.2.4, punycode@^1.4.1:
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
+puppeteer@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.6.1.tgz#ae50021bf8b2172be8f8d79224bec215f1a0c7c7"
+  dependencies:
+    debug "^3.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
+    mime "^2.0.3"
+    progress "^2.0.0"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^5.1.1"
 
 q@^1.1.2:
   version "1.5.1"
@@ -11003,7 +11104,7 @@ update-check@1.5.1:
     registry-auth-token "3.3.2"
     registry-url "3.1.0"
 
-update-notifier@^2.3.0:
+update-notifier@^2.3.0, update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   dependencies:
@@ -11484,6 +11585,18 @@ ws@3.0.0:
     safe-buffer "~5.0.1"
     ultron "~1.1.0"
 
+ws@^5.1.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.0.0.tgz#eaa494aded00ac4289d455bac8d84c7c651cef35"
+  dependencies:
+    async-limiter "~1.0.0"
+
 ws@~3.3.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
@@ -11539,6 +11652,10 @@ xstate@^3.1.0:
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xterm@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.5.1.tgz#d2e62ab26108a771b7bd1b7be4f6578fb4aff922"
 
 y18n@^3.2.1:
   version "3.2.1"
@@ -11634,6 +11751,12 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  dependencies:
+    fd-slicer "~1.0.1"
 
 yauzl@^2.2.1:
   version "2.9.1"


### PR DESCRIPTION
Gatsby's createPage expects a `path` field that must start with `/`.

The `slug`-related variables were spread all over and being used only for paths.

Since paths require a `/` at the beginning, the "prepend a `/` at the beginning" implementation detail was being repeated everywhere, and forgetting it caused a bug.

When prepending is forgotten, as in `CurriculumLink`, urls become relative, and a slug like `state/title` leads to a 404 url like `/state/state/title`.

This wasn't caught before because, by luck, on `/` because the relative and absolute paths coincided.

This fixes that and hides the implementation detail.